### PR TITLE
Add "buildProjectIDs" to ImageSecurityPolicy and check ProjectId of BuildProvenance in Build occurrence

### DIFF
--- a/artifacts/examples/image-security-policy-example.yaml
+++ b/artifacts/examples/image-security-policy-example.yaml
@@ -14,3 +14,5 @@ spec:
     whitelistCVEs:
       - providers/goog-vulnz/notes/CVE-2017-1000082
       - providers/goog-vulnz/notes/CVE-2017-1000081
+  builtProjectIDs:
+    - kritis-int-test

--- a/pkg/kritis/apis/kritis/v1beta1/securitypolicy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/securitypolicy.go
@@ -36,6 +36,8 @@ type ImageSecurityPolicySpec struct {
 	ImageWhitelist                   []string                         `json:"imageWhitelist"`
 	PackageVulnerabilityRequirements PackageVulnerabilityRequirements `json:"packageVulnerabilityRequirements"`
 	AttestationAuthorityNames        []string                         `json:"attestationAuthorityNames"`
+
+	BuiltProjectIDs []string `json:"builtProjectIDs"`
 }
 
 // PackageVulnerabilityRequirements is the requirements for package vulnz for an ImageSecurityPolicy

--- a/pkg/kritis/apis/kritis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/zz_generated.deepcopy.go
@@ -283,6 +283,11 @@ func (in *ImageSecurityPolicySpec) DeepCopyInto(out *ImageSecurityPolicySpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.BuiltProjectIDs != nil {
+		in, out := &in.BuiltProjectIDs, &out.BuiltProjectIDs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -18,6 +18,7 @@ package securitypolicy
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
@@ -145,7 +146,13 @@ func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, image string, 
 				NewViolation(
 					nil,
 					policy.BuildProjectIDViolation,
-					policy.Reason(fmt.Sprintf("%s doesn't have build occurence with required projectIDs", image)),
+					policy.Reason(
+						fmt.Sprintf(
+							"%s doesn't have build occurrence with required projectIDs: [%s]",
+							image,
+							strings.Join(isp.Spec.BuiltProjectIDs, ","),
+						),
+					),
 				),
 			)
 		}

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -208,3 +208,92 @@ func Test_OnlyFixesNotAvailablePassWithWhitelist(t *testing.T) {
 		t.Errorf("got unexpected violations: %v", violations)
 	}
 }
+
+func Test_BuiltProjectIDs(t *testing.T) {
+	t.Run("ISP has one buildProjjectIDs", func(t *testing.T) {
+		isp := v1beta1.ImageSecurityPolicy{
+			Spec: v1beta1.ImageSecurityPolicySpec{
+				BuiltProjectIDs: []string{"kritis-p-1"},
+			},
+		}
+
+		t.Run("should have a build projectID violation", func(t *testing.T) {
+			mc := &testutil.MockMetadataClient{
+				Build: []metadata.Build{},
+			}
+			violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
+			if err != nil {
+				t.Errorf("error validating isp: %v", err)
+			}
+			if len(violations) != 1 {
+				t.Errorf("should have a violation")
+			}
+		})
+		t.Run("allowed with correct build projectID", func(t *testing.T) {
+			mc := &testutil.MockMetadataClient{
+				Build: []metadata.Build{
+					{
+						Provenance: &metadata.BuildProvenance{
+							ProjectID: "kritis-p-1",
+							Creator:   "kritis-p-1@example.com",
+						},
+					},
+				},
+			}
+			violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
+			if err != nil {
+				t.Errorf("error validating isp: %v", err)
+			}
+			if violations != nil {
+				t.Errorf("got unexpected violations: %v", violations)
+			}
+		})
+	})
+
+	t.Run("ISP has 2 buildProjjectIDs", func(t *testing.T) {
+		isp := v1beta1.ImageSecurityPolicy{
+			Spec: v1beta1.ImageSecurityPolicySpec{
+				BuiltProjectIDs: []string{"kritis-p-1", "kritis-p-2"},
+			},
+		}
+
+		t.Run("should have a build projectID violation", func(t *testing.T) {
+			mc := &testutil.MockMetadataClient{
+				Build: []metadata.Build{
+					{
+						Provenance: &metadata.BuildProvenance{
+							ProjectID: "kritis-p-1",
+							Creator:   "kritis-p-1@example.com",
+						},
+					},
+				},
+			}
+			violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
+			if err != nil {
+				t.Errorf("error validating isp: %v", err)
+			}
+			if violations != nil {
+				t.Errorf("got unexpected violations: %v", violations)
+			}
+		})
+		t.Run("allowed with correct build projectID", func(t *testing.T) {
+			mc := &testutil.MockMetadataClient{
+				Build: []metadata.Build{
+					{
+						Provenance: &metadata.BuildProvenance{
+							ProjectID: "kritis-p-2",
+							Creator:   "kritis-p-2@example.com",
+						},
+					},
+				},
+			}
+			violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
+			if err != nil {
+				t.Errorf("error validating isp: %v", err)
+			}
+			if violations != nil {
+				t.Errorf("got unexpected violations: %v", violations)
+			}
+		})
+	})
+}

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -210,7 +210,7 @@ func Test_OnlyFixesNotAvailablePassWithWhitelist(t *testing.T) {
 }
 
 func Test_BuiltProjectIDs(t *testing.T) {
-	t.Run("ISP has one buildProjjectIDs", func(t *testing.T) {
+	t.Run("ISP has one buildProjectIDs", func(t *testing.T) {
 		isp := v1beta1.ImageSecurityPolicy{
 			Spec: v1beta1.ImageSecurityPolicySpec{
 				BuiltProjectIDs: []string{"kritis-p-1"},
@@ -250,7 +250,7 @@ func Test_BuiltProjectIDs(t *testing.T) {
 		})
 	})
 
-	t.Run("ISP has 2 buildProjjectIDs", func(t *testing.T) {
+	t.Run("ISP has 2 buildProjectIDs", func(t *testing.T) {
 		isp := v1beta1.ImageSecurityPolicy{
 			Spec: v1beta1.ImageSecurityPolicySpec{
 				BuiltProjectIDs: []string{"kritis-p-1", "kritis-p-2"},

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -210,21 +210,21 @@ func Test_OnlyFixesNotAvailablePassWithWhitelist(t *testing.T) {
 }
 
 func Test_BuiltProjectIDs(t *testing.T) {
-	type subTest struct {
+	type subCase struct {
 		name            string
 		buildProvenance *metadata.BuildProvenance
 		hasViolation    bool
 	}
 
-	var tests = []struct {
+	var cases = []struct {
 		name            string
 		builtProjectIDs []string
-		subTests        []subTest
+		subCases        []subCase
 	}{
 		{
 			"ISP has 1 buildProjectIDs",
 			[]string{"kritis-p-1"},
-			[]subTest{
+			[]subCase{
 				{
 					"should have a build projectID violation",
 					nil,
@@ -243,7 +243,7 @@ func Test_BuiltProjectIDs(t *testing.T) {
 		{
 			"ISP has 2 buildProjectIDs",
 			[]string{"kritis-p-1", "kritis-p-2"},
-			[]subTest{
+			[]subCase{
 				{
 					"should have a build projectID violation",
 					nil,
@@ -268,19 +268,19 @@ func Test_BuiltProjectIDs(t *testing.T) {
 			},
 		},
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
 			isp := v1beta1.ImageSecurityPolicy{
 				Spec: v1beta1.ImageSecurityPolicySpec{
-					BuiltProjectIDs: test.builtProjectIDs,
+					BuiltProjectIDs: c.builtProjectIDs,
 				},
 			}
-			for _, subTest := range test.subTests {
-				t.Run(subTest.name, func(t *testing.T) {
+			for _, sc := range c.subCases {
+				t.Run(sc.name, func(t *testing.T) {
 					mc := &testutil.MockMetadataClient{
 						Build: []metadata.Build{
 							{
-								Provenance: subTest.buildProvenance,
+								Provenance: sc.buildProvenance,
 							},
 						},
 					}
@@ -288,7 +288,7 @@ func Test_BuiltProjectIDs(t *testing.T) {
 					if err != nil {
 						t.Errorf("error validating isp: %v", err)
 					}
-					if subTest.hasViolation {
+					if sc.hasViolation {
 						if len(violations) != 1 {
 							t.Errorf("should have a violation")
 						}

--- a/pkg/kritis/metadata/containeranalysis/cache.go
+++ b/pkg/kritis/metadata/containeranalysis/cache.go
@@ -28,6 +28,7 @@ type Cache struct {
 	client metadata.Fetcher
 	vuln   map[string][]metadata.Vulnerability
 	att    map[string][]metadata.PGPAttestation
+	build  map[string][]metadata.Build
 	notes  map[*kritisv1beta1.AttestationAuthority]*grafeas.Note
 }
 
@@ -89,4 +90,16 @@ func (c Cache) AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas
 // CreateAttestationOccurence creates an Attestation occurrence for a given image and secret.
 func (c Cache) CreateAttestationOccurence(n *grafeas.Note, image string, p *secrets.PGPSigningSecret) (*grafeas.Occurrence, error) {
 	return c.client.CreateAttestationOccurence(n, image, p)
+}
+
+// Builds gets Build Occurrences for a specified image.
+func (c Cache) Builds(image string) ([]metadata.Build, error) {
+	if v, ok := c.build[image]; ok {
+		return v, nil
+	}
+	v, err := c.client.Builds(image)
+	if err != nil {
+		c.build[image] = v
+	}
+	return v, err
 }

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -231,6 +231,24 @@ func getProjectFromContainerImage(image string) string {
 	return tok[1]
 }
 
+// Builds gets Build Occurrences for a specified image.
+func (c Client) Builds(containerImage string) ([]metadata.Build, error) {
+	glog.Infof("getttig build occurrences for %s", containerImage)
+	occs, err := c.fetchOccurrence(containerImage, "BUILD")
+	if err != nil {
+		glog.Warning(err)
+		return nil, err
+	}
+	var builds []metadata.Build
+	for _, occ := range occs {
+		if v := util.GetBuildFromOccurrence(occ); v != nil {
+			builds = append(builds, *v)
+		}
+	}
+	glog.Infof("got build occurrences (%d) for %s", len(builds), containerImage)
+	return builds, nil
+}
+
 // The following methods are used for Testing
 
 // DeleteAttestationNote deletes a note for given AttestationAuthority

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -28,6 +28,7 @@ import (
 
 	"google.golang.org/grpc/credentials"
 
+	"github.com/golang/glog"
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	"github.com/grafeas/kritis/pkg/kritis/constants"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
@@ -244,6 +245,7 @@ func (c Client) Builds(containerImage string) ([]metadata.Build, error) {
 			builds = append(builds, *v)
 		}
 	}
+	glog.Infof("got build occurrences (%d) for %s", len(builds), containerImage)
 	return builds, nil
 }
 

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -232,6 +232,21 @@ func (c Client) CreateAttestationOccurence(note *grafeas.Note,
 	return c.client.CreateOccurrence(c.ctx, req)
 }
 
+// Builds gets Build Occurrences for a specified image.
+func (c Client) Builds(containerImage string) ([]metadata.Build, error) {
+	occs, err := c.fetchOccurrence(containerImage, "BUILD")
+	if err != nil {
+		return nil, err
+	}
+	var builds []metadata.Build
+	for _, occ := range occs {
+		if v := util.GetBuildFromOccurrence(occ); v != nil {
+			builds = append(builds, *v)
+		}
+	}
+	return builds, nil
+}
+
 func (c Client) fetchOccurrence(containerImage string, kind string) ([]*grafeas.Occurrence, error) {
 	req := &grafeas.ListOccurrencesRequest{
 		Filter:   fmt.Sprintf("resource_url=%q AND kind=%q", util.GetResourceURL(containerImage), kind),

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -235,6 +235,7 @@ func (c Client) CreateAttestationOccurence(note *grafeas.Note,
 
 // Builds gets Build Occurrences for a specified image.
 func (c Client) Builds(containerImage string) ([]metadata.Build, error) {
+	glog.Infof("getttig build occurrences for %s", containerImage)
 	occs, err := c.fetchOccurrence(containerImage, "BUILD")
 	if err != nil {
 		return nil, err

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -35,6 +35,9 @@ type Fetcher interface {
 	CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeasv1beta1.Note, error)
 	//Attestations get Attestation Occurrences for given image.
 	Attestations(containerImage string) ([]PGPAttestation, error)
+
+	// Builds get Build Occurrences for given image.
+	Builds(containerImage string) ([]Build, error)
 }
 
 type Vulnerability struct {
@@ -50,4 +53,13 @@ type PGPAttestation struct {
 	KeyID     string
 	// OccID is the occurrence ID for containeranalysis Occurrence_Attestation instance
 	OccID string
+}
+
+type Build struct {
+	Provenance *BuildProvenance
+}
+
+type BuildProvenance struct {
+	ProjectID string
+	Creator   string
 }

--- a/pkg/kritis/policy/violation.go
+++ b/pkg/kritis/policy/violation.go
@@ -28,6 +28,7 @@ const (
 	UnqualifiedImageViolation ViolationType = iota
 	FixUnavailableViolation
 	SeverityViolation
+	BuildProjectIDViolation
 )
 
 // Violation represents a Policy Violation.

--- a/pkg/kritis/testutil/metadata_mock.go
+++ b/pkg/kritis/testutil/metadata_mock.go
@@ -28,6 +28,7 @@ import (
 type MockMetadataClient struct {
 	Vulnz           []metadata.Vulnerability
 	PGPAttestations []metadata.PGPAttestation
+	Build           []metadata.Build
 	Occ             map[string]string
 }
 
@@ -63,11 +64,16 @@ func (m *MockMetadataClient) Attestations(containerImage string) ([]metadata.PGP
 	return m.PGPAttestations, nil
 }
 
+func (m *MockMetadataClient) Builds(containerImage string) ([]metadata.Build, error) {
+	return m.Build, nil
+}
+
 func NilFetcher() func() (metadata.Fetcher, error) {
 	return func() (metadata.Fetcher, error) {
 		return &MockMetadataClient{
 			Vulnz:           []metadata.Vulnerability{},
 			PGPAttestations: []metadata.PGPAttestation{},
+			Build:           []metadata.Build{},
 		}, nil
 	}
 }

--- a/pkg/kritis/util/util.go
+++ b/pkg/kritis/util/util.go
@@ -95,3 +95,16 @@ func GetOrCreateAttestationNote(c metadata.Fetcher, a *v1beta1.AttestationAuthor
 	}
 	return c.CreateAttestationNote(a)
 }
+
+func GetBuildFromOccurrence(occ *grafeas.Occurrence) *metadata.Build {
+	build := occ.GetBuild()
+	if build == nil {
+		return nil
+	}
+	return &metadata.Build{
+		Provenance: &metadata.BuildProvenance{
+			ProjectID: build.Provenance.ProjectId,
+			Creator:   build.Provenance.Creator,
+		},
+	}
+}


### PR DESCRIPTION
## WHAT
This pull request adds "buildProjectIDs" to ImageSecurityPolicy and check ProjectId of BuildProvenance in Build occurrence.

## WHY
We would like to check BUILD occurrence of docker images so that we can ensure the docker images were built on the specific GCP project's Cloud Build.
