### PR TITLE
Add "image.pullSecrets" to helm values to specify imagePullSecrets for deployment and hook jobs

### DIFF
--- a/kritis-charts/Chart.yaml
+++ b/kritis-charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: release-201903
 description: A Helm chart for Kritis
 name: kritis-charts
-version: 0.1.0-mercari.1
+version: 0.1.0-mercari.2

--- a/kritis-charts/templates/kritis-server-deployment.yaml
+++ b/kritis-charts/templates/kritis-server-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
       - name: {{ . }}
-      {{- end}}
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ .Values.image.name }}

--- a/kritis-charts/templates/kritis-server-deployment.yaml
+++ b/kritis-charts/templates/kritis-server-deployment.yaml
@@ -24,6 +24,12 @@ spec:
         label: {{ .Values.serviceLabel }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+      - name: {{ . }}
+      {{- end}}
+      {{- end }}
       containers:
       - name: {{ .Values.image.name }}
         image: "{{ .Values.repository }}{{ .Values.image.image }}:{{ .Values.image.tag }}"

--- a/kritis-charts/templates/postinstall/1_job.yaml
+++ b/kritis-charts/templates/postinstall/1_job.yaml
@@ -16,6 +16,12 @@ spec:
       labels:
         app: {{ .Values.postinstall.job.name }}
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: {{ .Values.postinstall.job.name }}

--- a/kritis-charts/templates/postinstall/1_job.yaml
+++ b/kritis-charts/templates/postinstall/1_job.yaml
@@ -20,7 +20,7 @@ spec:
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
         - name: {{ . }}
-      {{- end}}
+      {{- end }}
       {{- end }}
       restartPolicy: Never
       containers:

--- a/kritis-charts/templates/predelete/1_job.yaml
+++ b/kritis-charts/templates/predelete/1_job.yaml
@@ -17,6 +17,12 @@ spec:
       labels:
         app: {{ .Values.predelete.job.name }}
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: {{ .Values.predelete.job.name }}

--- a/kritis-charts/templates/predelete/1_job.yaml
+++ b/kritis-charts/templates/predelete/1_job.yaml
@@ -21,7 +21,7 @@ spec:
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
         - name: {{ . }}
-      {{- end}}
+      {{- end }}
       {{- end }}
       restartPolicy: Never
       containers:

--- a/kritis-charts/templates/preinstall/3_job.yaml
+++ b/kritis-charts/templates/preinstall/3_job.yaml
@@ -16,6 +16,12 @@ spec:
       labels:
         app: {{ .Values.preinstall.job.name }}
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
       restartPolicy: Never
       serviceAccountName: {{ .Values.preinstall.serviceAccount }}
       containers:

--- a/kritis-charts/templates/preinstall/3_job.yaml
+++ b/kritis-charts/templates/preinstall/3_job.yaml
@@ -20,7 +20,7 @@ spec:
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
         - name: {{ . }}
-      {{- end}}
+      {{- end }}
       {{- end }}
       restartPolicy: Never
       serviceAccountName: {{ .Values.preinstall.serviceAccount }}

--- a/kritis-charts/values.yaml
+++ b/kritis-charts/values.yaml
@@ -9,6 +9,8 @@ image:
   image: kritis-server
   name: kritis-server
   pullPolicy: Always
+  # pullSecrets:
+  #   - myRegistrKeySecretName
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## WHAT
This pull request adds "image.pullSecrets" to helm values to specify imagePullSecrets for deployment and hook jobs.

## WHY
Since we might use in-house registry for docker images, we need to specify the imagePullSecrets to get those images.