### PR TITLE
Comment out "checkOwners" since it doesn't work expectedly now

### DIFF
--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -38,7 +38,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/violation"
 	"k8s.io/api/admission/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -206,11 +206,15 @@ func ReviewHandler(w http.ResponseWriter, r *http.Request, config *Config) {
 
 func reviewDeployment(deployment *appsv1.Deployment, ar *v1beta1.AdmissionReview, config *Config) {
 	images := DeploymentImages(*deployment)
-	// check if the Deployments's owner has already been validated
-	if checkOwners(images, &deployment.ObjectMeta) {
-		glog.Infof("all owners for Deployment %s have been validated, returning successful status", deployment.Name)
-		return
-	}
+
+	// Commented out (dragon3)
+	//
+	// // check if the Deployments's owner has already been validated
+	// if checkOwners(images, &deployment.ObjectMeta) {
+	// 	glog.Infof("all owners for Deployment %s have been validated, returning successful status", deployment.Name)
+	// 	return
+	// }
+
 	// check for a breakglass annotation on the deployment
 	if checkBreakglass(&deployment.ObjectMeta) {
 		glog.Infof("found breakglass annotation for %s, returning successful status", deployment.Name)
@@ -259,11 +263,15 @@ func reviewImages(images []string, ns string, pod *v1.Pod, ar *v1beta1.Admission
 
 func reviewPod(pod *v1.Pod, ar *v1beta1.AdmissionReview, config *Config) {
 	images := PodImages(*pod)
-	// check if the Pod's owner has already been validated
-	if checkOwners(images, &pod.ObjectMeta) {
-		glog.Infof("all owners for Pod %s have been validated, returning sucessful status", pod.Name)
-		return
-	}
+
+	// Commented out (dragon3)
+	//
+	// // check if the Pod's owner has already been validated
+	// if checkOwners(images, &pod.ObjectMeta) {
+	// 	glog.Infof("all owners for Pod %s have been validated, returning sucessful status", pod.Name)
+	// 	return
+	// }
+
 	// check for a breakglass annotation on the pod
 	if checkBreakglass(&pod.ObjectMeta) {
 		glog.Infof("found breakglass annotation for %s, returning successful status", pod.Name)
@@ -274,11 +282,15 @@ func reviewPod(pod *v1.Pod, ar *v1beta1.AdmissionReview, config *Config) {
 
 func reviewReplicaSet(replicaSet *appsv1.ReplicaSet, ar *v1beta1.AdmissionReview, config *Config) {
 	images := ReplicaSetImages(*replicaSet)
-	// check if the ReplicaSet's owner has already been validated
-	if checkOwners(images, &replicaSet.ObjectMeta) {
-		glog.Infof("all owners for ReplicaSet %s have been validated, returning successful status", replicaSet.Name)
-		return
-	}
+
+	// Commented out (dragon3)
+	//
+	// // check if the ReplicaSet's owner has already been validated
+	// if checkOwners(images, &replicaSet.ObjectMeta) {
+	// 	glog.Infof("all owners for ReplicaSet %s have been validated, returning successful status", replicaSet.Name)
+	// 	return
+	// }
+
 	// check for a breakglass annotation on the replica set
 	if checkBreakglass(&replicaSet.ObjectMeta) {
 		glog.Infof("found breakglass annotation for %s, returning successful status", replicaSet.Name)


### PR DESCRIPTION
## WHAT
This pull request comments out (disable) "checkOwners" since it doesn't work expectedly now.

## WHY
It's possible to override "image" with any docker images with violation because [now the validation admission webhook for Deployment doesn't check "UPDATE" operation](https://github.com/grafeas/kritis/blob/v0.1.0/helm-hooks/postinstall/postinstall.go#L111-L113), then Kritis allows any docker images in ReplicaSet and Pod creation because of the `checkOwners`.

If we add "UPDATE" operation to the webhook for Deployment, the webhook can get AdmissionReview for Deployment update but it cause another issue which we can't know the admission comes from "UPDATE" or "DELETE" operation. (Both sends "UPDATE" admission)
It's probably because the admission's Kind is "extensions/v1beta1" and it doesn't support "DELETE" operation.

So for now it's better to **disable** the `checkOwners` so that we can reject docker images when Deployment updated.
