### PR TITLE
Set "resources" value to deployment manifest

### DIFF
--- a/kritis-charts/Chart.yaml
+++ b/kritis-charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: release-201903
 description: A Helm chart for Kritis
 name: kritis-charts
-version: 0.1.0-mercari.1
+version: 0.1.0-mercari.3

--- a/kritis-charts/templates/kritis-server-deployment.yaml
+++ b/kritis-charts/templates/kritis-server-deployment.yaml
@@ -43,6 +43,10 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secret/{{ .Values.gacSecret.path }}
+{{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
       volumes:
         - name: tls
           secret:


### PR DESCRIPTION
## WHAT
This pull request set `resources` value to deployment manifest.

## WHY
The `resources` value is defined in `values.yaml` but it's not used in the deployment manifest.
This pull request fixes it.
