### PR TITLE
Fix nil pointer error in test

### DIFF
--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -277,12 +277,14 @@ func Test_BuiltProjectIDs(t *testing.T) {
 			}
 			for _, sc := range c.subCases {
 				t.Run(sc.name, func(t *testing.T) {
+					builds := []metadata.Build{}
+					if sc.buildProvenance != nil {
+						builds = append(builds, metadata.Build{
+							Provenance: sc.buildProvenance,
+						})
+					}
 					mc := &testutil.MockMetadataClient{
-						Build: []metadata.Build{
-							{
-								Provenance: sc.buildProvenance,
-							},
-						},
+						Build: builds,
 					}
 					violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
 					if err != nil {


### PR DESCRIPTION
This pull request fixes a nil pointer error in test.
This error was introduced in 7909262.

```
=== RUN   Test_BuiltProjectIDs/ISP_has_1_buildProjectIDs/should_have_a_build_projectID_violation
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1ba0c9c]

goroutine 59 [running]:
testing.tRunner.func1(0xc000125d00)
    /usr/local/opt/go/libexec/src/testing/testing.go:792 +0x387
panic(0x1cb5fa0, 0x2995430)
    /usr/local/opt/go/libexec/src/runtime/panic.go:513 +0x1b9
github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy.ValidateImageSecurityPolicy(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /***/src/github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy/securitypolicy.go:134 +0x4dc
github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy.Test_BuiltProjectIDs.func1.1(0xc000125d00)
    /***/src/github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy/securitypolicy_test.go:287 +0x123
testing.tRunner(0xc000125d00, 0xc0003c6080)
    /usr/local/opt/go/libexec/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
    /usr/local/opt/go/libexec/src/testing/testing.go:878 +0x353
FAIL    github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy    0.052s
```
