### PR TITLE
Ignore validation for Update events when images are not changed

### DIFF
--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -119,7 +119,6 @@ func handleDeployment(ar *v1beta1.AdmissionReview, admitResponse *v1beta1.Admiss
 		}
 	}
 
-	glog.Infof("handling deployment %s...", deployment.Name)
 	reviewDeployment(&deployment, admitResponse, config)
 	return nil
 }

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -115,6 +115,7 @@ func handleDeployment(ar *v1beta1.AdmissionReview, admitResponse *v1beta1.Admiss
 		// Before deleting a deployment, kubernetes always make replicas to 0 which causes an
 		// UPDATE event.
 		if !hasNewImage(DeploymentImages(deployment), DeploymentImages(oldDeployment)) {
+			glog.Infof("ignoring deployment %s as no new image has been added", deployment.Name)
 			return nil
 		}
 	}
@@ -154,6 +155,7 @@ func handleReplicaSet(ar *v1beta1.AdmissionReview, admitResponse *v1beta1.Admiss
 		// Before deleting a replicaSet, kubernetes always make replicas to 0 which causes an
 		// UPDATE event.
 		if !hasNewImage(ReplicaSetImages(replicaSet), ReplicaSetImages(oldReplicaSet)) {
+			glog.Infof("ignoring replica set %s as no new image has been added", replicaSet.Name)
 			return nil
 		}
 	}

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -101,6 +101,25 @@ func handleDeployment(ar *v1beta1.AdmissionReview, admitResponse *v1beta1.Admiss
 		return err
 	}
 	glog.Infof("handling deployment %s...", deployment.Name)
+
+	operation := ar.Request.Operation
+	if operation == v1beta1.Update {
+		oldDeployment := appsv1.Deployment{}
+		if err := json.Unmarshal(ar.Request.OldObject.Raw, &oldDeployment); err != nil {
+			return err
+		}
+
+		// For UPDATE events, if there is no new image added, we can skip the check.
+		// This is required, so that DELETE events work for Deployment.
+		//
+		// Before deleting a deployment, kubernetes always make replicas to 0 which causes an
+		// UPDATE event.
+		if !hasNewImage(DeploymentImages(deployment), DeploymentImages(oldDeployment)) {
+			return nil
+		}
+	}
+
+	glog.Infof("handling deployment %s...", deployment.Name)
 	reviewDeployment(&deployment, admitResponse, config)
 	return nil
 }
@@ -121,6 +140,24 @@ func handleReplicaSet(ar *v1beta1.AdmissionReview, admitResponse *v1beta1.Admiss
 		return err
 	}
 	glog.Infof("handling replica set %s...", replicaSet.Name)
+
+	operation := ar.Request.Operation
+	if operation == v1beta1.Update {
+		oldReplicaSet := appsv1.ReplicaSet{}
+		if err := json.Unmarshal(ar.Request.OldObject.Raw, &oldReplicaSet); err != nil {
+			return err
+		}
+
+		// For UPDATE events, if there is no new image added, we can skip the check.
+		// This is required, so that DELETE events work for ReplicaSet.
+		//
+		// Before deleting a replicaSet, kubernetes always make replicas to 0 which causes an
+		// UPDATE event.
+		if !hasNewImage(ReplicaSetImages(replicaSet), ReplicaSetImages(oldReplicaSet)) {
+			return nil
+		}
+	}
+
 	reviewReplicaSet(&replicaSet, admitResponse, config)
 	return nil
 }

--- a/pkg/kritis/admission/images.go
+++ b/pkg/kritis/admission/images.go
@@ -56,3 +56,19 @@ func ReplicaSetImages(rs appsv1.ReplicaSet) []string {
 	}
 	return images
 }
+
+func hasNewImage(images, oldImages []string) bool {
+	for _, image := range images {
+		var isOld bool
+		for _, oldImage := range oldImages {
+			if image == oldImage {
+				isOld = true
+			}
+		}
+		if !isOld {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/kritis/admission/images_test.go
+++ b/pkg/kritis/admission/images_test.go
@@ -100,3 +100,47 @@ func Test_ReplicaSetImages(t *testing.T) {
 	actual := ReplicaSetImages(rs)
 	testutil.DeepEqual(t, expected, actual)
 }
+
+func Test_hasNewImage(t *testing.T) {
+	cases := map[string]struct {
+		images    []string
+		oldImages []string
+		want      bool
+	}{
+		"noImages": {
+			images:    []string{""},
+			oldImages: []string{""},
+			want:      false,
+		},
+		"sameImages": {
+			images:    []string{"image1"},
+			oldImages: []string{"image1"},
+			want:      false,
+		},
+		"differentImages": {
+			images:    []string{"image0"},
+			oldImages: []string{"image1"},
+			want:      true,
+		},
+		"noNewImage": {
+			images:    []string{"image1"},
+			oldImages: []string{"image0", "image1"},
+			want:      false,
+		},
+		"newImage": {
+			images:    []string{"image2"},
+			oldImages: []string{"image0", "image1"},
+			want:      true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := hasNewImage(tc.images, tc.oldImages)
+
+			if tc.want != got {
+				t.Fatalf("got %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request fixes an issue where after enabling Kritis, users cannot delete old deployment or replicaset. 

This issue was caused after enabling `UPDATE` events for deployments. Whenever a deployment is deleted, kubernetes API will first make its replica to 0 which will trigger an `UPDATE` event. Since, these are old deployments and images are not signed, so Kritis will deny this change and this will fail deploy delete operation. 

This PR will ignore all the UPDATE events where images are same as old images. Basically all those changes where no new image is added. 

