### PR TITLE
Remove "Fingerprint" from AttestorPublicKey

### DIFF
--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -367,9 +367,8 @@ func Test_RequireAttestationsBy(t *testing.T) {
 					Name: "attestor-1",
 					PublicKeys: []*AttestorPublicKey{
 						{
-							ID:          "attestor-1-id",
-							AsciiArmor:  testutil.Base64PublicTestKey(t),
-							Fingerprint: testutil.PgpKeyFingerprint,
+							ID:         testutil.PgpKeyFingerprint,
+							AsciiArmor: testutil.Base64PublicTestKey(t),
 						},
 					},
 				}, nil


### PR DESCRIPTION
## WHAT

This pull request removes `Fingerprint` from `AttestorPublicKey`.

## WHY

Attestor's public key from Binary Authorization API has ID which is actually fingerprint of the key.
So we can remove `Fingerprint` from `AttestorPublicKey` and unnecessary fingerprint calculation.
