### PR TITLE
Add cluster-wide image whitelist using KritisConfig CRD

### DIFF
--- a/artifacts/examples/kritis-config-example.yaml
+++ b/artifacts/examples/kritis-config-example.yaml
@@ -2,8 +2,10 @@ apiVersion: kritis.grafeas.io/v1beta1
 kind: KritisConfig
 metadata:
   name: kritis-config
-  namespace: default
 spec:
   metadataBackend: containerAnalysis
   cronInterval: 1h
   serverAddr: :443
+  imageWhitelist:
+  - istio/proxy_init
+  - istio/proxyv2

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -282,7 +282,7 @@ func reviewImages(images []string, ns string, pod *v1.Pod, ar *v1beta1.Admission
 		return
 	}
 	if len(isps) == 0 {
-		glog.Errorf("no ImageSecurityPolicy found in namespace %s, skip reviewing", ns)
+		glog.Infof("no ImageSecurityPolicy found in namespace %s, skip reviewing", ns)
 		return
 	}
 

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -33,6 +33,7 @@ import (
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	kritisconstants "github.com/grafeas/kritis/pkg/kritis/constants"
 	"github.com/grafeas/kritis/pkg/kritis/crd/authority"
+	"github.com/grafeas/kritis/pkg/kritis/crd/kritisconfig"
 	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
 	"github.com/grafeas/kritis/pkg/kritis/review"
@@ -397,12 +398,13 @@ func getReviewer(client metadata.Fetcher) reviewer {
 	}
 
 	return review.New(client, &review.Config{
-		Strategy:  defaultViolationStrategy,
-		IsWebhook: true,
-		Secret:    secrets.Fetch,
-		Auths:     authority.Authority,
-		Validate:  securitypolicy.ValidateImageSecurityPolicy,
-		Attestors: attestorFetcher,
+		Strategy:                        defaultViolationStrategy,
+		IsWebhook:                       true,
+		Secret:                          secrets.Fetch,
+		Auths:                           authority.Authority,
+		Validate:                        securitypolicy.ValidateImageSecurityPolicy,
+		Attestors:                       attestorFetcher,
+		ClusterWhitelistedImagesRemover: kritisconfig.RemoveWhitelistedImages,
 	})
 }
 

--- a/pkg/kritis/apis/kritis/v1beta1/kritisconfig.go
+++ b/pkg/kritis/apis/kritis/v1beta1/kritisconfig.go
@@ -22,6 +22,7 @@ import (
 
 // +genclient
 // +genclient:noStatus
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type KritisConfig struct {
@@ -41,6 +42,9 @@ type KritisConfigSpec struct {
 	ServerAddr string `json:"serverAddr"`
 	// Grafeas configuration used for communicating with Grafeas backend
 	Grafeas GrafeasConfigSpec `json:"grafeas"`
+
+	// ImageWhitelist used for admit docker images without validating
+	ImageWhitelist []string `json:"imageWhitelist"`
 }
 
 // GrafeasConfigSpec holds the configuration required for connecting to grafeas instance

--- a/pkg/kritis/apis/kritis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/zz_generated.deepcopy.go
@@ -311,7 +311,7 @@ func (in *KritisConfig) DeepCopyInto(out *KritisConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	return
 }
 
@@ -370,6 +370,11 @@ func (in *KritisConfigList) DeepCopyObject() runtime.Object {
 func (in *KritisConfigSpec) DeepCopyInto(out *KritisConfigSpec) {
 	*out = *in
 	out.Grafeas = in.Grafeas
+	if in.ImageWhitelist != nil {
+		in, out := &in.ImageWhitelist, &out.ImageWhitelist
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/fake/fake_kritis_client.go
+++ b/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/fake/fake_kritis_client.go
@@ -40,8 +40,8 @@ func (c *FakeKritisV1beta1) ImageSecurityPolicies(namespace string) v1beta1.Imag
 	return &FakeImageSecurityPolicies{c, namespace}
 }
 
-func (c *FakeKritisV1beta1) KritisConfigs(namespace string) v1beta1.KritisConfigInterface {
-	return &FakeKritisConfigs{c, namespace}
+func (c *FakeKritisV1beta1) KritisConfigs() v1beta1.KritisConfigInterface {
+	return &FakeKritisConfigs{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/fake/fake_kritisconfig.go
+++ b/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/fake/fake_kritisconfig.go
@@ -31,7 +31,6 @@ import (
 // FakeKritisConfigs implements KritisConfigInterface
 type FakeKritisConfigs struct {
 	Fake *FakeKritisV1beta1
-	ns   string
 }
 
 var kritisconfigsResource = schema.GroupVersionResource{Group: "kritis", Version: "v1beta1", Resource: "kritisconfigs"}
@@ -41,8 +40,7 @@ var kritisconfigsKind = schema.GroupVersionKind{Group: "kritis", Version: "v1bet
 // Get takes name of the kritisConfig, and returns the corresponding kritisConfig object, and an error if there is any.
 func (c *FakeKritisConfigs) Get(name string, options v1.GetOptions) (result *v1beta1.KritisConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(kritisconfigsResource, c.ns, name), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootGetAction(kritisconfigsResource, name), &v1beta1.KritisConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeKritisConfigs) Get(name string, options v1.GetOptions) (result *v1b
 // List takes label and field selectors, and returns the list of KritisConfigs that match those selectors.
 func (c *FakeKritisConfigs) List(opts v1.ListOptions) (result *v1beta1.KritisConfigList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(kritisconfigsResource, kritisconfigsKind, c.ns, opts), &v1beta1.KritisConfigList{})
-
+		Invokes(testing.NewRootListAction(kritisconfigsResource, kritisconfigsKind, opts), &v1beta1.KritisConfigList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeKritisConfigs) List(opts v1.ListOptions) (result *v1beta1.KritisCon
 // Watch returns a watch.Interface that watches the requested kritisConfigs.
 func (c *FakeKritisConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(kritisconfigsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(kritisconfigsResource, opts))
 }
 
 // Create takes the representation of a kritisConfig and creates it.  Returns the server's representation of the kritisConfig, and an error, if there is any.
 func (c *FakeKritisConfigs) Create(kritisConfig *v1beta1.KritisConfig) (result *v1beta1.KritisConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(kritisconfigsResource, c.ns, kritisConfig), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootCreateAction(kritisconfigsResource, kritisConfig), &v1beta1.KritisConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeKritisConfigs) Create(kritisConfig *v1beta1.KritisConfig) (result *
 // Update takes the representation of a kritisConfig and updates it. Returns the server's representation of the kritisConfig, and an error, if there is any.
 func (c *FakeKritisConfigs) Update(kritisConfig *v1beta1.KritisConfig) (result *v1beta1.KritisConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(kritisconfigsResource, c.ns, kritisConfig), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootUpdateAction(kritisconfigsResource, kritisConfig), &v1beta1.KritisConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -103,14 +97,13 @@ func (c *FakeKritisConfigs) Update(kritisConfig *v1beta1.KritisConfig) (result *
 // Delete takes name of the kritisConfig and deletes it. Returns an error if one occurs.
 func (c *FakeKritisConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(kritisconfigsResource, c.ns, name), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootDeleteAction(kritisconfigsResource, name), &v1beta1.KritisConfig{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeKritisConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(kritisconfigsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(kritisconfigsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.KritisConfigList{})
 	return err
@@ -119,8 +112,7 @@ func (c *FakeKritisConfigs) DeleteCollection(options *v1.DeleteOptions, listOpti
 // Patch applies the patch and returns the patched kritisConfig.
 func (c *FakeKritisConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.KritisConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(kritisconfigsResource, c.ns, name, data, subresources...), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(kritisconfigsResource, name, data, subresources...), &v1beta1.KritisConfig{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/kritis_client.go
+++ b/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/kritis_client.go
@@ -50,8 +50,8 @@ func (c *KritisV1beta1Client) ImageSecurityPolicies(namespace string) ImageSecur
 	return newImageSecurityPolicies(c, namespace)
 }
 
-func (c *KritisV1beta1Client) KritisConfigs(namespace string) KritisConfigInterface {
-	return newKritisConfigs(c, namespace)
+func (c *KritisV1beta1Client) KritisConfigs() KritisConfigInterface {
+	return newKritisConfigs(c)
 }
 
 // NewForConfig creates a new KritisV1beta1Client for the given config.

--- a/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/kritisconfig.go
+++ b/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/kritisconfig.go
@@ -30,7 +30,7 @@ import (
 // KritisConfigsGetter has a method to return a KritisConfigInterface.
 // A group's client should implement this interface.
 type KritisConfigsGetter interface {
-	KritisConfigs(namespace string) KritisConfigInterface
+	KritisConfigs() KritisConfigInterface
 }
 
 // KritisConfigInterface has methods to work with KritisConfig resources.
@@ -49,14 +49,12 @@ type KritisConfigInterface interface {
 // kritisConfigs implements KritisConfigInterface
 type kritisConfigs struct {
 	client rest.Interface
-	ns     string
 }
 
 // newKritisConfigs returns a KritisConfigs
-func newKritisConfigs(c *KritisV1beta1Client, namespace string) *kritisConfigs {
+func newKritisConfigs(c *KritisV1beta1Client) *kritisConfigs {
 	return &kritisConfigs{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -64,7 +62,6 @@ func newKritisConfigs(c *KritisV1beta1Client, namespace string) *kritisConfigs {
 func (c *kritisConfigs) Get(name string, options v1.GetOptions) (result *v1beta1.KritisConfig, err error) {
 	result = &v1beta1.KritisConfig{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -77,7 +74,6 @@ func (c *kritisConfigs) Get(name string, options v1.GetOptions) (result *v1beta1
 func (c *kritisConfigs) List(opts v1.ListOptions) (result *v1beta1.KritisConfigList, err error) {
 	result = &v1beta1.KritisConfigList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -89,7 +85,6 @@ func (c *kritisConfigs) List(opts v1.ListOptions) (result *v1beta1.KritisConfigL
 func (c *kritisConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -99,7 +94,6 @@ func (c *kritisConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *kritisConfigs) Create(kritisConfig *v1beta1.KritisConfig) (result *v1beta1.KritisConfig, err error) {
 	result = &v1beta1.KritisConfig{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		Body(kritisConfig).
 		Do().
@@ -111,7 +105,6 @@ func (c *kritisConfigs) Create(kritisConfig *v1beta1.KritisConfig) (result *v1be
 func (c *kritisConfigs) Update(kritisConfig *v1beta1.KritisConfig) (result *v1beta1.KritisConfig, err error) {
 	result = &v1beta1.KritisConfig{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		Name(kritisConfig.Name).
 		Body(kritisConfig).
@@ -123,7 +116,6 @@ func (c *kritisConfigs) Update(kritisConfig *v1beta1.KritisConfig) (result *v1be
 // Delete takes name of the kritisConfig and deletes it. Returns an error if one occurs.
 func (c *kritisConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		Name(name).
 		Body(options).
@@ -134,7 +126,6 @@ func (c *kritisConfigs) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *kritisConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -146,7 +137,6 @@ func (c *kritisConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions 
 func (c *kritisConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.KritisConfig, err error) {
 	result = &v1beta1.KritisConfig{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/kritis/client/listers/kritis/v1beta1/expansion_generated.go
+++ b/pkg/kritis/client/listers/kritis/v1beta1/expansion_generated.go
@@ -45,7 +45,3 @@ type ImageSecurityPolicyNamespaceListerExpansion interface{}
 // KritisConfigListerExpansion allows custom methods to be added to
 // KritisConfigLister.
 type KritisConfigListerExpansion interface{}
-
-// KritisConfigNamespaceListerExpansion allows custom methods to be added to
-// KritisConfigNamespaceLister.
-type KritisConfigNamespaceListerExpansion interface{}

--- a/pkg/kritis/client/listers/kritis/v1beta1/kritisconfig.go
+++ b/pkg/kritis/client/listers/kritis/v1beta1/kritisconfig.go
@@ -29,8 +29,8 @@ import (
 type KritisConfigLister interface {
 	// List lists all KritisConfigs in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.KritisConfig, err error)
-	// KritisConfigs returns an object that can list and get KritisConfigs.
-	KritisConfigs(namespace string) KritisConfigNamespaceLister
+	// Get retrieves the KritisConfig from the index for a given name.
+	Get(name string) (*v1beta1.KritisConfig, error)
 	KritisConfigListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *kritisConfigLister) List(selector labels.Selector) (ret []*v1beta1.Krit
 	return ret, err
 }
 
-// KritisConfigs returns an object that can list and get KritisConfigs.
-func (s *kritisConfigLister) KritisConfigs(namespace string) KritisConfigNamespaceLister {
-	return kritisConfigNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// KritisConfigNamespaceLister helps list and get KritisConfigs.
-type KritisConfigNamespaceLister interface {
-	// List lists all KritisConfigs in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1beta1.KritisConfig, err error)
-	// Get retrieves the KritisConfig from the indexer for a given namespace and name.
-	Get(name string) (*v1beta1.KritisConfig, error)
-	KritisConfigNamespaceListerExpansion
-}
-
-// kritisConfigNamespaceLister implements the KritisConfigNamespaceLister
-// interface.
-type kritisConfigNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all KritisConfigs in the indexer for a given namespace.
-func (s kritisConfigNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.KritisConfig, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.KritisConfig))
-	})
-	return ret, err
-}
-
-// Get retrieves the KritisConfig from the indexer for a given namespace and name.
-func (s kritisConfigNamespaceLister) Get(name string) (*v1beta1.KritisConfig, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the KritisConfig from the index for a given name.
+func (s *kritisConfigLister) Get(name string) (*v1beta1.KritisConfig, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kritis/crd/kritisconfig/kritisconfig.go
+++ b/pkg/kritis/crd/kritisconfig/kritisconfig.go
@@ -18,6 +18,7 @@ package kritisconfig
 
 import (
 	"github.com/pkg/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
@@ -25,9 +26,8 @@ import (
 	clientset "github.com/grafeas/kritis/pkg/kritis/client/clientset/versioned"
 )
 
-// KritisConfigs returns all KritisConfigs in the specified namespace
-// Pass in an empty string to get all KritisConfigs in all namespaces
-func KritisConfigs(namespace string) ([]v1beta1.KritisConfig, error) {
+// KritisConfig returns KritisConfig in the cluster
+func KritisConfig() (*v1beta1.KritisConfig, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "error building config")
@@ -37,24 +37,17 @@ func KritisConfigs(namespace string) ([]v1beta1.KritisConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error building clientset")
 	}
-	list, err := client.KritisV1beta1().KritisConfigs(namespace).List(metav1.ListOptions{})
+
+	list, err := client.KritisV1beta1().KritisConfigs().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing all kritis configs")
 	}
-	return list.Items, nil
-}
 
-// KritisConfig returns the KritisConfig in the specified namespace and with the given name
-// Returns error if KritisConfig is not found
-func KritisConfig(namespace string, name string) (*v1beta1.KritisConfig, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "error building config")
+	if len(list.Items) > 1 {
+		return nil, errors.New("more than 1 KritisConfig found, expected to have only 1 in the cluster")
+	} else if len(list.Items) == 0 {
+		return nil, nil
 	}
 
-	client, err := clientset.NewForConfig(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "error building clientset")
-	}
-	return client.KritisV1beta1().KritisConfigs(namespace).Get(name, metav1.GetOptions{})
+	return &list.Items[0], nil
 }

--- a/pkg/kritis/crd/kritisconfig/kritisconfig_test.go
+++ b/pkg/kritis/crd/kritisconfig/kritisconfig_test.go
@@ -1,0 +1,127 @@
+package kritisconfig
+
+import (
+	"testing"
+
+	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+)
+
+func Test_imageInWhitelist(t *testing.T) {
+	cases := map[string]struct {
+		whitelist []string
+		image     string
+		wanted    bool
+	}{
+		"empty whitelist": {
+			[]string{},
+			"gcr.io/foo/bar",
+			false,
+		},
+		"gcr image is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"gcr.io/foo/bar",
+			true,
+		},
+		"gcr image with tag is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"gcr.io/foo/bar:0.0.1",
+			true,
+		},
+		"gcr image with digest is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"gcr.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			true,
+		},
+		"gcr image is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"gcr.io/foo/baz",
+			false,
+		},
+		"gcr image with tag is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"gcr.io/foo/baz:0.0.1",
+			false,
+		},
+		"gcr image with digest is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"gcr.io/foo/baz@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			false,
+		},
+		"public image is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"datawire/telepresence-k8s",
+			true,
+		},
+		"public image with tag is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"datawire/telepresence-k8s:0.0.1",
+			true,
+		},
+		"public image with digest is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"datawire/telepresence-k8s@sha256:1aeb301df7a2e53c6b9b5b16ed9b123ebd584bfa6ad0325e54118e377b2d8d52",
+			true,
+		},
+		"public image is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"datawire/telepresence-foo",
+			false,
+		},
+		"public image with tag is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"datawire/telepresence-foo:0.0.1",
+			false,
+		},
+		"public image with digest is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s"},
+			"datawire/telepresence-foo@sha256:1aeb301df7a2e53c6b9b5b16ed9b123ebd584bfa6ad0325e54118e377b2d8d52",
+			false,
+		},
+		"public library image is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s", "nginx"},
+			"nginx",
+			true,
+		},
+		"public library image with tag is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s", "nginx"},
+			"nginx:1.0.0",
+			true,
+		},
+		"public library image with digest is in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s", "nginx"},
+			"nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			true,
+		},
+		"public library image is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s", "nginx"},
+			"apache",
+			false,
+		},
+		"public library image with tag is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s", "nginx"},
+			"apache:1.0.0",
+			false,
+		},
+		"public library image with digest is NOT in whitelist": {
+			[]string{"gcr.io/foo/bar", "datawire/telepresence-k8s", "nginx"},
+			"apache@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			false,
+		},
+	}
+
+	for n, c := range cases {
+		t.Run(n, func(t *testing.T) {
+			yes, err := imageInWhitelist(&v1beta1.KritisConfig{
+				Spec: v1beta1.KritisConfigSpec{
+					ImageWhitelist: c.whitelist,
+				},
+			}, c.image)
+			if err != nil {
+				t.Errorf("got unexpected error: %+v", err)
+			}
+			if yes != c.wanted {
+				t.Errorf("wanted %t but got %t", c.wanted, yes)
+			}
+		})
+	}
+}

--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -64,6 +64,7 @@ func ImageSecurityPolicies(namespace string) ([]v1beta1.ImageSecurityPolicy, err
 func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, image string, metadataFetcher metadata.Fetcher, attestorFetcher AttestorFetcher) ([]policy.Violation, error) {
 	// First, check if image is whitelisted
 	if imageInWhitelist(isp, image) {
+		glog.Infof("%q is whitelisted in ImageSecurityPolicy", image)
 		return nil, nil
 	}
 	var violations []policy.Violation

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -329,9 +329,6 @@ func newTestAttestorFetcher(getAttestor func(name string) (*Attestor, error)) At
 }
 
 func Test_RequireAttestationsBy(t *testing.T) {
-	// TODO: implement
-	t.Log("TODO: implement")
-
 	cases := []struct {
 		name            string
 		hasError        bool

--- a/pkg/kritis/cron/cron.go
+++ b/pkg/kritis/cron/cron.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 
 	"github.com/grafeas/kritis/pkg/kritis/crd/authority"
+	"github.com/grafeas/kritis/pkg/kritis/crd/kritisconfig"
 	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/violation"
 	corev1 "k8s.io/api/core/v1"
@@ -64,12 +65,13 @@ func NewCronConfig(cs *kubernetes.Clientset, client metadata.Fetcher) *Config {
 		PodLister: pods.Pods,
 		Client:    client,
 		ReviewConfig: &review.Config{
-			Secret:    secrets.Fetch,
-			Auths:     authority.Authority,
-			Strategy:  defaultViolationStrategy,
-			IsWebhook: false,
-			Validate:  securitypolicy.ValidateImageSecurityPolicy,
-			Attestors: attestorFetcher,
+			Secret:                          secrets.Fetch,
+			Auths:                           authority.Authority,
+			Strategy:                        defaultViolationStrategy,
+			IsWebhook:                       false,
+			Validate:                        securitypolicy.ValidateImageSecurityPolicy,
+			Attestors:                       attestorFetcher,
+			ClusterWhitelistedImagesRemover: kritisconfig.RemoveWhitelistedImages,
 		},
 		SecurityPolicyLister: securitypolicy.ImageSecurityPolicies,
 	}

--- a/pkg/kritis/cron/cron_test.go
+++ b/pkg/kritis/cron/cron_test.go
@@ -33,6 +33,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func NoopClusterWhitelistedImagesRemover(images []string) ([]string, error) {
+	return images, nil
+}
+
 func TestStartCancels(t *testing.T) {
 
 	// Speed up the checks for testing.
@@ -204,11 +208,12 @@ func TestCheckPods(t *testing.T) {
 			Attestations: map[string]bool{},
 		}
 		tt.args.cfg.ReviewConfig = &review.Config{
-			Validate:  tt.args.validate,
-			Secret:    sMock,
-			Auths:     aMock,
-			IsWebhook: false,
-			Strategy:  &th,
+			Validate:                        tt.args.validate,
+			Secret:                          sMock,
+			Auths:                           aMock,
+			IsWebhook:                       false,
+			Strategy:                        &th,
+			ClusterWhitelistedImagesRemover: NoopClusterWhitelistedImagesRemover,
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			if err := CheckPods(tt.args.cfg, tt.args.isps); err != nil {

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -33,6 +33,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func NoopClusterWhitelistedImagesRemover(images []string) ([]string, error) {
+	return images, nil
+}
+
 func TestHasValidAttestations(t *testing.T) {
 	successSec, pub := testutil.CreateSecret(t, "test-success")
 	successFpr := successSec.PgpKey.Fingerprint()
@@ -98,10 +102,11 @@ func TestHasValidAttestations(t *testing.T) {
 				PGPAttestations: tc.attestations,
 			}
 			r := New(cMock, &Config{
-				Validate:  nil,
-				Secret:    sMock,
-				IsWebhook: true,
-				Strategy:  nil,
+				Validate:                        nil,
+				Secret:                          sMock,
+				IsWebhook:                       true,
+				Strategy:                        nil,
+				ClusterWhitelistedImagesRemover: NoopClusterWhitelistedImagesRemover,
 			})
 			actual := r.hasValidImageAttestations(testutil.QualifiedImage, tc.attestations, auths)
 			if actual != tc.expected {
@@ -284,11 +289,12 @@ func TestReview(t *testing.T) {
 				PGPAttestations: tc.attestations,
 			}
 			r := New(cMock, &Config{
-				Validate:  mockValidate,
-				Secret:    sMock,
-				Auths:     authMock,
-				IsWebhook: tc.isWebhook,
-				Strategy:  &th,
+				Validate:                        mockValidate,
+				Secret:                          sMock,
+				Auths:                           authMock,
+				IsWebhook:                       tc.isWebhook,
+				Strategy:                        &th,
+				ClusterWhitelistedImagesRemover: NoopClusterWhitelistedImagesRemover,
 			})
 			if err := r.Review([]string{tc.image}, isps, nil); (err != nil) != tc.shdErr {
 				t.Errorf("expected review to return error %t, actual error %s", tc.shdErr, err)

--- a/pkg/kritis/util/whitelist.go
+++ b/pkg/kritis/util/whitelist.go
@@ -17,10 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"reflect"
-
 	"github.com/golang/glog"
 	"github.com/google/go-containerregistry/pkg/name"
+
 	"github.com/grafeas/kritis/pkg/kritis/constants"
 )
 
@@ -28,7 +27,7 @@ import (
 func RemoveGloballyWhitelistedImages(images []string) []string {
 	notWhitelisted := []string{}
 	for _, image := range images {
-		whitelisted, err := imageInWhitelist(image)
+		whitelisted, err := ImageInWhitelist(constants.GlobalImageWhitelist, image)
 		if err != nil {
 			glog.Errorf("couldn't check if %s is in global whitelist: %v", image, err)
 		}
@@ -39,8 +38,8 @@ func RemoveGloballyWhitelistedImages(images []string) []string {
 	return notWhitelisted
 }
 
-func imageInWhitelist(image string) (bool, error) {
-	for _, w := range constants.GlobalImageWhitelist {
+func ImageInWhitelist(whitelist []string, image string) (bool, error) {
+	for _, w := range whitelist {
 		whitelistRef, err := name.ParseReference(w, name.WeakValidation)
 		if err != nil {
 			return false, err
@@ -49,8 +48,9 @@ func imageInWhitelist(image string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
+
 		// Make sure images have the same context
-		if reflect.DeepEqual(whitelistRef.Context(), imageRef.Context()) {
+		if whitelistRef.Context().Name() == imageRef.Context().Name() {
 			return true, nil
 		}
 	}

--- a/pkg/kritis/util/whitelist.go
+++ b/pkg/kritis/util/whitelist.go
@@ -49,7 +49,7 @@ func ImageInWhitelist(whitelist []string, image string) (bool, error) {
 			return false, err
 		}
 
-		// Make sure images have the same context
+		// Make sure images have the same name
 		if whitelistRef.Context().Name() == imageRef.Context().Name() {
 			return true, nil
 		}

--- a/pkg/kritis/util/whitelist_test.go
+++ b/pkg/kritis/util/whitelist_test.go
@@ -54,37 +54,51 @@ func Test_RemoveGloballyWhitelistedImages(t *testing.T) {
 
 func Test_ImageInWhitelist(t *testing.T) {
 	tests := []struct {
-		name     string
-		image    string
-		expected bool
+		name      string
+		image     string
+		whitelist []string
+		expected  bool
 	}{
 		{
-			name:     "test image with tag in whitelist",
-			image:    "gcr.io/kritis-project/kritis-server:tag",
+			name:  "test image with tag in whitelist",
+			image: "gcr.io/kritis-project/kritis-server:tag",
+			whitelist: []string{
+				"gcr.io/kritis-project/kritis-server",
+				"nginx",
+			},
 			expected: true,
 		},
 		{
-			name:     "test image with digest in whitelist",
-			image:    "gcr.io/kritis-project/kritis-server@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			name:  "test image with digest in whitelist",
+			image: "gcr.io/kritis-project/kritis-server@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			whitelist: []string{
+				"gcr.io/kritis-project/kritis-server",
+				"nginx",
+			},
 			expected: true,
 		},
 		{
-			name:     "test public image in whitelist",
-			image:    "nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			name:  "test public image in whitelist",
+			image: "nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			whitelist: []string{
+				"gcr.io/kritis-project/kritis-server",
+				"nginx",
+			},
 			expected: true,
 		},
 		{
-			name:     "test image not in whitelist",
-			image:    "some/image",
+			name:  "test image not in whitelist",
+			image: "some/image",
+			whitelist: []string{
+				"gcr.io/kritis-project/kritis-server",
+				"nginx",
+			},
 			expected: false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := ImageInWhitelist([]string{
-				"gcr.io/kritis-project/kritis-server",
-				"nginx",
-			}, test.image)
+			actual, err := ImageInWhitelist(test.whitelist, test.image)
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, actual)
 		})
 	}

--- a/pkg/kritis/util/whitelist_test.go
+++ b/pkg/kritis/util/whitelist_test.go
@@ -52,15 +52,25 @@ func Test_RemoveGloballyWhitelistedImages(t *testing.T) {
 	}
 }
 
-func Test_imageInWhitelist(t *testing.T) {
+func Test_ImageInWhitelist(t *testing.T) {
 	tests := []struct {
 		name     string
 		image    string
 		expected bool
 	}{
 		{
-			name:     "test image in whitelist",
+			name:     "test image with tag in whitelist",
 			image:    "gcr.io/kritis-project/kritis-server:tag",
+			expected: true,
+		},
+		{
+			name:     "test image with digest in whitelist",
+			image:    "gcr.io/kritis-project/kritis-server@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			expected: true,
+		},
+		{
+			name:     "test public image in whitelist",
+			image:    "nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000",
 			expected: true,
 		},
 		{
@@ -71,7 +81,10 @@ func Test_imageInWhitelist(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := imageInWhitelist(test.image)
+			actual, err := ImageInWhitelist([]string{
+				"gcr.io/kritis-project/kritis-server",
+				"nginx",
+			}, test.image)
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
## WHAT

This pull request adds cluster-wide image whitelisting feature.

## WHY

We need whitelist feature:
- to allow developers to use [Telepresence](https://www.telepresence.io/) which deploys docker images provided by them
- to use Istio-sidecar
- etc

Currently Kritis has `whitelist` feature which has 2 levels:
1. Global whitelist ([hardcoded](https://github.com/grafeas/kritis/blob/master/pkg/kritis/constants/constants.go#L55-L58))
2. ImageSecurityPolicy whitelist (CRD)

But it's not useful for our use-case because:
- (1) is [hardcoded](https://github.com/grafeas/kritis/blob/master/pkg/kritis/constants/constants.go#L55-L58), we don't want to do that. and whitelist could be different between dev and prod.
- (2) is per namespace, we want to have cluster-wide whitelist. Also ImageSecurityPolicy's whitelist is check strictly with image digest. ( can't allow like `gcr.io/foo/bar` )

