### PR TITLE
Bump version to v0.3.0-meracri.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GOOS ?= $(shell go env GOOS)
 GOARCH = amd64
 BUILD_DIR ?= ./out
 COMMIT ?= $(shell git rev-parse HEAD)
-VERSION ?= v0.1.0
+VERSION ?= v0.3.0-mercari.1
 IMAGE_TAG ?= $(COMMIT)
 
 # Used for integration testing. example:


### PR DESCRIPTION
## WHAT

This pull request just updates `VERSION` to `v0.3.0-meracri.1`.

## WHY

Finished implementation for [Add cluster-wide image whitelist using KritisConfig CRD](https://github.com/mercari/kritis/pull/15), so release new version.
