### PR TITLE
Fix memory leak

### DIFF
--- a/cmd/kritis/admission/main.go
+++ b/cmd/kritis/admission/main.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/golang/glog"
 	"github.com/grafeas/kritis/cmd/kritis/version"
 	"github.com/grafeas/kritis/pkg/kritis/admission"

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Builds the static Go image for Admission validation controller.
 
-FROM golang:1.10
+FROM golang:1.12
 WORKDIR /go/src/github.com/grafeas/kritis
 COPY . .
 RUN make out/kritis-server

--- a/deploy/Dockerfile_resolve
+++ b/deploy/Dockerfile_resolve
@@ -15,7 +15,7 @@
 # Builds the static Go image for Admission validation controller.
 
 # Dockerfile used to build a build step that builds resolve-tags in CI.
-FROM golang:1.10
+FROM golang:1.12
 RUN mkdir -p /go/src/github.com/grafeas/
 RUN ln -s /workspace /go/src/github.com/grafeas/kritis
 WORKDIR /go/src/github.com/grafeas/kritis

--- a/deploy/kritis-gcb-signer/Dockerfile
+++ b/deploy/kritis-gcb-signer/Dockerfile
@@ -14,7 +14,7 @@
 
 # Builds the static Go image for Admission validation controller.
 
-FROM golang:1.10
+FROM golang:1.12
 WORKDIR /go/src/github.com/grafeas/kritis
 COPY . .
 RUN make out/gcb-signer

--- a/deploy/kritis-int-test/Dockerfile
+++ b/deploy/kritis-int-test/Dockerfile
@@ -49,7 +49,7 @@ FROM runtime_deps as builder
 RUN apt-get install --no-install-recommends --no-install-suggests -y \
         build-essential
 
-COPY --from=golang:1.10 /usr/local/go /usr/local/go
+COPY --from=golang:1.12 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/go/bin:${PATH}
 ENV GOPATH /go/
 

--- a/helm-hooks/Dockerfile
+++ b/helm-hooks/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10
+FROM golang:1.12
 WORKDIR /go/src/github.com/grafeas/kritis
 COPY . .
 ARG stage
-RUN make ${stage} 
+RUN make ${stage}
 
 
-FROM golang:1.10
+FROM golang:1.12
 RUN go get -u github.com/cloudflare/cfssl/cmd/...
 
 ENV KUBECTL_VERSION v1.10.0

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -298,6 +298,8 @@ func reviewImages(images []string, ns string, pod *v1.Pod, ar *v1beta1.Admission
 	}
 
 	client, err := admissionConfig.fetchMetadataClient(config)
+	defer client.Close()
+
 	if err != nil {
 		errMsg := fmt.Sprintf("error getting metadata client: %v", err)
 		glog.Errorf(errMsg)

--- a/pkg/kritis/kubectl/plugins/resolve/resolve_test.go
+++ b/pkg/kritis/kubectl/plugins/resolve/resolve_test.go
@@ -31,7 +31,7 @@ metadata:
 spec:
   containers:
   - name: docker
-    image: golang:1.10
+    image: golang:1.12
     args: ["--arg1=<first>",
            "--arg2=<second>",
            "--arg3=<third>"]
@@ -66,7 +66,7 @@ func Test_recursiveGetTaggedImages(t *testing.T) {
 			name: "test one tagged image",
 			yaml: testYaml1,
 			expected: []string{
-				"golang:1.10",
+				"golang:1.12",
 			},
 		},
 		{
@@ -123,7 +123,7 @@ func setResolver(f func(string) (string, error)) func() {
 func Test_resolveTagsToDigests(t *testing.T) {
 	r := newFakeResolver()
 	r.tagMap["gcr.io/google-appengine/debian9:2017-09-07-161610"] = "gcr.io/google-appengine/debian9@sha256:foo"
-	r.tagMap["golang:1.10"] = "index.docker.io/library/golang@sha256:bar"
+	r.tagMap["golang:1.12"] = "index.docker.io/library/golang@sha256:bar"
 
 	defer setResolver(r.resolve)()
 
@@ -144,10 +144,10 @@ func Test_resolveTagsToDigests(t *testing.T) {
 		{
 			name: "docker registry image",
 			images: []string{
-				"golang:1.10",
+				"golang:1.12",
 			},
 			expected: map[string]string{
-				"golang:1.10": "index.docker.io/library/golang@sha256:bar",
+				"golang:1.12": "index.docker.io/library/golang@sha256:bar",
 			},
 		},
 	}

--- a/pkg/kritis/metadata/containeranalysis/cache.go
+++ b/pkg/kritis/metadata/containeranalysis/cache.go
@@ -46,6 +46,11 @@ func NewCache() (*Cache, error) {
 	}, nil
 }
 
+// Close closes connection
+func (c Cache) Close() {
+	c.client.Close()
+}
+
 // Vulnerabilities gets Package Vulnerabilities Occurrences for a specified image.
 func (c Cache) Vulnerabilities(image string) ([]metadata.Vulnerability, error) {
 	if v, ok := c.vuln[image]; ok {

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -58,6 +58,11 @@ func New() (*Client, error) {
 	}, nil
 }
 
+// Close closes connection
+func (c Client) Close() {
+	c.client.Close()
+}
+
 //Vulnerabilities gets Package Vulnerabilities Occurrences for a specified image.
 func (c Client) Vulnerabilities(containerImage string) ([]metadata.Vulnerability, error) {
 	occs, err := c.fetchOccurrence(containerImage, PkgVulnerability)

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -52,6 +52,11 @@ type Client struct {
 	ctx    context.Context
 }
 
+// Close closes connection
+func (c Client) Close() {
+	// Not Implemented
+}
+
 // ValidateConfig checks whether the specified configuration is valid
 func ValidateConfig(config kritisv1beta1.GrafeasConfigSpec) error {
 	if config.Addr == "" {

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -38,6 +38,9 @@ type Fetcher interface {
 
 	// Builds get Build Occurrences for given image.
 	Builds(containerImage string) ([]Build, error)
+
+	// Close client connection
+	Close()
 }
 
 type Vulnerability struct {

--- a/pkg/kritis/testutil/metadata_mock.go
+++ b/pkg/kritis/testutil/metadata_mock.go
@@ -32,6 +32,9 @@ type MockMetadataClient struct {
 	Occ             map[string]string
 }
 
+func (m *MockMetadataClient) Close() {
+	// No Ops
+}
 func (m *MockMetadataClient) Vulnerabilities(containerImage string) ([]metadata.Vulnerability, error) {
 	return m.Vulnz, nil
 }


### PR DESCRIPTION
## What
- [x] Update golang version to 1.12
   Without this docker image does not get build because of cfssl master branch is not compatible with 1.10. (https://github.com/mercari/kritis/blob/master/helm-hooks/Dockerfile#L23)

- [x] Fixes memory leak issue. 

In current Kritis implementation, GrafeasClient is created inside the request handler and they are not closed gracefully after the request has been handled. This creates memory leak. 

A better approach might be to create grafeasclient before handling requests and use same client for all goroutines (request handler) but this will require more refactoring. This is a quick fix and works well. 

