### PR TITLE
Upgrade kubectl version to v1.16.4 for Helm hooks

### DIFF
--- a/helm-hooks/Dockerfile
+++ b/helm-hooks/Dockerfile
@@ -22,7 +22,7 @@ RUN make ${stage}
 FROM golang:1.12
 RUN go get -u github.com/cloudflare/cfssl/cmd/...
 
-ENV KUBECTL_VERSION v1.10.0
+ENV KUBECTL_VERSION v1.16.4
 RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl  && \
     chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
## WHAT

This pull request upgrade `kubectl` command in Helm hooks container to `v1.16.4`.

## WHY

We got an similar issue to https://github.com/grafeas/kritis/issues/434 and need to do the same as https://github.com/grafeas/kritis/pull/443
