### PR TITLE
Bump VERSION to "v0.4.1-mercari.1"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GOOS ?= $(shell go env GOOS)
 GOARCH = amd64
 BUILD_DIR ?= ./out
 COMMIT ?= $(shell git rev-parse HEAD)
-VERSION ?= v0.4.0-mercari.1
+VERSION ?= v0.4.1-mercari.1
 IMAGE_TAG ?= $(COMMIT)
 
 # Used for integration testing. example:


### PR DESCRIPTION
## WHAT

This pull request bump `VERSION` to `v0.4.1-mercari.1`.

## WHY

To release https://github.com/mercari/kritis/pull/21
