### PR TITLE
Print violation types

### DIFF
--- a/pkg/kritis/policy/violation.go
+++ b/pkg/kritis/policy/violation.go
@@ -32,6 +32,18 @@ const (
 	RequiredAttestationViolation
 )
 
+func (v ViolationType) ToString() string {
+	str := map[ViolationType]string{
+		UnqualifiedImageViolation:    "UnqualifiedImageViolation",
+		FixUnavailableViolation:      "FixUnavailableViolation",
+		SeverityViolation:            "SeverityViolation",
+		BuildProjectIDViolation:      "BuildProjectIDViolation",
+		RequiredAttestationViolation: "RequiredAttestationViolation",
+	}
+
+	return str[v]
+}
+
 // Violation represents a Policy Violation.
 type Violation interface {
 	Type() ViolationType

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -166,13 +166,14 @@ Please see instructions `, image)
 }
 
 func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []policy.Violation) error {
-	errMsg := fmt.Sprintf("found violations in %q", image)
-	// Check if one of the violations is that the image is not fully qualified
+	violationTypes := make([]string, len(violations))
+
 	for _, v := range violations {
-		if v.Type() == policy.UnqualifiedImageViolation {
-			errMsg = fmt.Sprintf(`%q is not a fully qualified image. You can run 'kubectl plugin resolve-tags' to qualify all images with a digest. Instructions for installing the plugin can be found at https://github.com/grafeas/kritis/blob/master/cmd/kritis/kubectl/plugins/resolve`, image)
-		}
+		violationTypes = append(violationTypes, fmt.Sprintf("%s", v.Type().ToString()))
 	}
+
+	errMsg := fmt.Sprintf("found violations in %q (%v)", image, violationTypes)
+
 	if err := r.config.Strategy.HandleViolation(image, pod, violations); err != nil {
 		return errors.Wrapf(err, "failed to handle violation: %s", errMsg)
 	}

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -167,7 +167,7 @@ Please see instructions `, image)
 }
 
 func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []policy.Violation) error {
-	violationSummaries := make([]string, len(violations))
+	var violationSummaries []string
 
 	for _, v := range violations {
 		violationSummaries = append(violationSummaries, fmt.Sprintf("%s: %s", v.Type().ToString(), v.Reason()))


### PR DESCRIPTION
## WHAT

Print more detailed violation types and violation reasons.

## WHY

Because currently in certain places it's not possible to quickly look up further information about violations. This makes debugging violation messages easier.